### PR TITLE
Updated Dockerfile to use official base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jenkins:latest
+FROM jenkins/jenkins:latest
 
 ENV JENKINS_HOME /var/jenkins_home
 ENV CERT_FOLDER "$JENKINS_HOME/.ssl"


### PR DESCRIPTION
Official Jenkins base image has moved from jenkins:latest to jenkins/jenkins:latest in dockerhub
Changes are done to Docker file for using official image as base image