### PR TITLE
Update tini path to "/sbin/tini" to remove warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ ENV JENKINS_OPTS --httpPort=-1 --httpsPort=8443 --httpsCertificate="$CERT_FOLDER
 EXPOSE 8443
 
 USER ${user}
-ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/jenkins_cert.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins_cert.sh"]


### PR DESCRIPTION
Hi! I tried to use your docker image and find an issue.

```
***************************************************************************
* WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING *
***************************************************************************
Please update your scripts to use /sbin/tini or simply tini going forward.
Previous path has been preserved for backwards compatibility,
but WILL BE REMOVED in the future. (around Jenkins >= 2.107.2+)
Now sleeping 2 minutes...
```
So I updated the tini path and it worked. Please allow this PR. 
Thanks!